### PR TITLE
Set self-hosted default gha

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -65,6 +65,11 @@ on:
         required: false
         default: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -98,6 +103,7 @@ jobs:
     with:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -118,6 +124,7 @@ jobs:
       exclusive: false
       env-label: |
         preview: deploy
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}

--- a/.github/workflows/hotfix-branch.yml
+++ b/.github/workflows/hotfix-branch.yml
@@ -65,6 +65,11 @@ on:
         required: false
         default: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -98,6 +103,7 @@ jobs:
     with:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -118,6 +124,7 @@ jobs:
       exclusive: true
       env-label: |
         hotfix: deploy
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}

--- a/.github/workflows/hotfix-mixin.yml
+++ b/.github/workflows/hotfix-mixin.yml
@@ -43,6 +43,11 @@ on:
         description: "Release version tag"
         required: true
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
 
 permissions:
   id-token: write
@@ -57,3 +62,4 @@ jobs:
     uses: cloudposse/github-action-workflows/.github/workflows/controller-hotfix-release-branch.yml@main
     with:
       version: ${{ inputs.version }}
+      runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -49,6 +49,11 @@ on:
         required: true
         type: string
         default: main
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -80,6 +85,7 @@ jobs:
     with:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -91,6 +97,7 @@ jobs:
     uses: cloudposse/github-actions-workflows/.github/workflows/controller-hotfix-release.yml@main
     with:
       ref: ${{ github.sha }}
+      runs-on: ${{ inputs.runs-on }}
 
   promote:
     needs: [release]
@@ -99,6 +106,7 @@ jobs:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
       version: ${{ needs.release.outputs.version }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -114,6 +122,7 @@ jobs:
       tag: ${{ needs.promote.outputs.tag }}
       repository: ${{ inputs.repository }}
       environment: production
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
@@ -124,6 +133,7 @@ jobs:
     with:
       ref: ${{ github.ref }}
       target_branch: ${{ inputs.default_branch }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
 

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -44,6 +44,11 @@ on:
         required: false
         default: ${{ github.event.repository.name }}
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -75,6 +80,7 @@ jobs:
     with:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -89,6 +95,7 @@ jobs:
       tag: ${{ needs.ci.outputs.tag }}
       repository: ${{ inputs.repository }}
       environment: dev
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
@@ -96,5 +103,7 @@ jobs:
   release:
     uses:  cloudposse/github-actions-workflows/.github/workflows/controller-draft-release.yml@main
     needs: [ cd ]
+    with:
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ on:
         required: false
         default: ${{ github.event.release.tag_name }}
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -82,6 +87,7 @@ jobs:
       organization: ${{ inputs.organization }}
       repository: ${{ inputs.repository }}
       version: ${{ inputs.version }}
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       ecr-region: ${{ secrets.ecr-region }}
       ecr-iam-role: ${{ secrets.ecr-iam-role }}
@@ -97,6 +103,7 @@ jobs:
       tag: ${{ needs.ci.outputs.tag }}
       repository: ${{ inputs.repository }}
       environment: staging
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}
@@ -110,6 +117,7 @@ jobs:
       tag: ${{ needs.ci.outputs.tag }}
       repository: ${{ inputs.repository }}
       environment: production
+      runs-on: ${{ inputs.runs-on }}
     secrets:
       secret-outputs-passphrase: ${{ secrets.secret-outputs-passphrase }}
       github-private-actions-pat: ${{ secrets.github-private-actions-pat }}


### PR DESCRIPTION
## what
* Use `self-hosted-default` gha runners

## references
* DEV-2353 Review workflows in the cloudposse org for specific runs-on settings on self-hosted runners and ensure they have the correct labels and include core-auto
